### PR TITLE
 Move responsibility to re-add handler to config

### DIFF
--- a/src/config_listener_mon.erl
+++ b/src/config_listener_mon.erl
@@ -12,11 +12,14 @@
 
 -module(config_listener_mon).
 -behaviour(gen_server).
--vsn(1).
+-vsn(2).
 
 
 -export([
-    subscribe/2
+    subscribe/2,
+    terminate_config/2,
+    notify/5,
+    restart/2
 ]).
 
 
@@ -32,53 +35,142 @@
 
 -record(st, {
     pid,
-    ref
+    ref,
+    mgr,
+    state,
+    self,
+    module
 }).
 
+-define(RELISTEN_DELAY, 500).
 
 subscribe(Module, InitSt) ->
     proc_lib:start(?MODULE, init, [{self(), Module, InitSt}]).
 
+notify(#st{module = Mod, state = State, pid = Pid} = St,
+        Sec, Key, Value, Persist) ->
+    try Mod:handle_config_change(Sec, Key, Value, Persist, State) of
+        {ok, NewState} ->
+            {ok, St#st{state = NewState}};
+        remove_handler ->
+            remove_handler
+    catch
+        _:Error ->
+            {swap_handler, {remove_handler_due_to_error, {error, Error}},
+                St, {config_listener, {Mod, Pid}}, St}
+    end.
 
 init({Pid, Mod, InitSt}) ->
+    process_flag(trap_exit, true),
     Ref = erlang:monitor(process, Pid),
-    case config_listener:start(Mod, {Mod, Pid}, {Pid, InitSt}) of
-        ok ->
+    case listen(#st{module = Mod, pid = Pid, ref = Ref, state = InitSt}) of
+        {ok, St} ->
             proc_lib:init_ack(ok),
-            gen_server:enter_loop(?MODULE, [], #st{pid = Pid, ref = Ref});
+            gen_server:enter_loop(?MODULE, [], St);
         Else ->
             proc_lib:init_ack(Else)
     end.
 
-
-terminate(_Reason, _St) ->
+terminate(_Reason, _) ->
     ok.
 
+terminate_config({remove_handler_due_to_error, Reason}, #st{} = St) ->
+    handle_config_terminate(Reason, St),
+    ok;
+terminate_config({swapped, _, _}, _St) ->
+    ok;
+terminate_config(Reason, St) ->
+    maybe_restart(handle_config_terminate(Reason, St)).
 
+handle_call(stop, _From, St) ->
+    {stop, normal, St};
 handle_call(_Message, _From, St) ->
     {reply, ignored, St}.
-
 
 handle_cast(_Message, St) ->
     {noreply, St}.
 
-
+%% Requester die
 handle_info({'DOWN', Ref, _, _, _}, #st{ref = Ref} = St) ->
     {stop, normal, St};
 
-handle_info({gen_event_EXIT, {config_listener, Module}, Reason}, St)  ->
+%% Event handler swapped due to error in terminate
+handle_info({gen_event_EXIT, {config_listener, _Id}, {swapped, _, _}}, St)  ->
+    {noreply, St};
+
+%% Event handler die
+handle_info({gen_event_EXIT, {config_listener, Id}, Reason}, St)  ->
     Level = case Reason of
         normal -> debug;
         shutdown -> debug;
         _ -> error
     end,
     Fmt = "config_listener(~p) for ~p stopped with reason: ~r~n",
-    couch_log:Level(Fmt, [Module, St#st.pid, Reason]),
+    couch_log:Level(Fmt, [Id, St#st.pid, Reason]),
+    {stop, Reason, St};
+
+%% Event manager die
+handle_info({'EXIT', EventMgr, shutdown}, #st{mgr = EventMgr} = St) ->
     {stop, shutdown, St};
+handle_info({'EXIT', EventMgr, _Reason}, #st{mgr = EventMgr} = St) ->
+    {noreply, St, ?RELISTEN_DELAY};
 
-handle_info(_, St) ->
+handle_info(timeout, St) ->
+    case whereis(config_event) of
+        undefined ->
+            {noreply, St, ?RELISTEN_DELAY};
+        EventMgr ->
+            {noreply, listen(St#st{mgr = EventMgr})}
+    end;
+handle_info(_Event, St) ->
     {noreply, St}.
-
 
 code_change(_OldVsn, St, _Extra) ->
     {ok, St}.
+
+listen(#st{module = Mod, pid = Pid} = St0) ->
+    St = St0#st{self = self(), mgr = whereis(config_event)},
+    case config_listener:listen({Mod, Pid}, St) of
+        ok ->
+            {ok, St};
+        Else ->
+            Else
+    end.
+
+handle_config_terminate(Reason, #st{module = Mod, pid = Pid, state = State} = St) ->
+    try {Mod:handle_config_terminate(Pid, Reason, State), Reason} of
+        {remove_handler, _} ->
+            ok;
+        {_, normal} ->
+            ok;
+        {_, shutdown} ->
+            ok;
+        {_, remove_handler} ->
+            ok;
+        {_, {remove_handler, _Reason}} ->
+            ok;
+        {{ok, NewState}, _Reason} ->
+            St#st{state = NewState};
+         {_, _Reason} ->
+            St
+    catch
+        Kind:Error ->
+            couch_log:error(
+               "config_listener(~p) for ~p crashed in handle_config_terminate: ~p:~p~n",
+               [Mod, Pid, Kind, Error]),
+            St
+    end.
+
+maybe_restart(#st{} = St) ->
+    spawn(fun() -> restart(?RELISTEN_DELAY, St) end);
+maybe_restart(_) ->
+    ok.
+
+restart(Delay, #st{module = Mod, pid = Pid, state = State} = St) ->
+    case catch proc_lib:start(?MODULE, init, [{Pid, Mod, State}]) of
+        ok ->
+            ok;
+        _ ->
+            timer:sleep(Delay),
+            restart(Delay, St)
+    end.

--- a/test/config_tests.erl
+++ b/test/config_tests.erl
@@ -454,16 +454,16 @@ should_not_call_handle_config_after_related_process_death(Pid) ->
 
 should_remove_handler_when_requested(Pid) ->
     ?_test(begin
-        ?assertEqual(2, n_handlers()),
+        ?assertEqual(1, n_handlers()),
         ?assertEqual(ok, config:set("remove_handler", "any", "any", false)),
         ?assertEqual({Pid, remove_handler, undefined}, getmsg(Pid)),
-        ?assertEqual(1, n_handlers())
+        ?assertEqual(0, n_handlers())
     end).
 
 
 should_remove_handler_when_pid_exits(Pid) ->
     ?_test(begin
-        ?assertEqual(2, n_handlers()),
+        ?assertEqual(1, n_handlers()),
 
         % Monitor the config_listener_mon process
         {monitored_by, [Mon]} = process_info(Pid, monitored_by),
@@ -486,13 +486,13 @@ should_remove_handler_when_pid_exits(Pid) ->
             erlang:error({timeout, config_listener_mon_death})
         end,
 
-        ?assertEqual(1, n_handlers())
+        ?assertEqual(0, n_handlers())
     end).
 
 
 should_stop_monitor_on_error(Pid) ->
     ?_test(begin
-        ?assertEqual(2, n_handlers()),
+        ?assertEqual(1, n_handlers()),
 
         % Monitor the config_listener_mon process
         {monitored_by, [Mon]} = process_info(Pid, monitored_by),
@@ -513,7 +513,7 @@ should_stop_monitor_on_error(Pid) ->
             erlang:error({timeout, config_listener_mon_shutdown})
         end,
 
-        ?assertEqual(1, n_handlers())
+        ?assertEqual(0, n_handlers())
     end).
 
 
@@ -572,4 +572,8 @@ getmsg(Pid) ->
 
 
 n_handlers() ->
-    length(gen_event:which_handlers(config_event)).
+    length(handlers()).
+
+handlers() ->
+    Handlers = gen_event:which_handlers(config_event),
+    [Pid || {config_listener, {?MODULE, Pid}} <- Handlers].

--- a/test/config_tests.erl
+++ b/test/config_tests.erl
@@ -93,7 +93,7 @@ teardown(_, _) ->
     teardown(undefined).
 
 
-handle_config_change("remove_handler", _Key, _Value, _Persist, {Pid, _State}) ->
+handle_config_change("remove_handler", _Key, _Value, _Persist, {_Pid, _State}) ->
     remove_handler;
 
 handle_config_change("update_state", Key, Value, Persist, {Pid, State}) ->


### PR DESCRIPTION
We move responsibility to re-add handler from config_listener behaviour
to config_listener_mon module.

gen_event behaviour is a tricky one. Due to its prehistoric times it
uses links instead of monitors (which didn't exist at that time). This
makes dealing with gen_event manager restart tricky.

We use {swap_handler, Reason, OldState, NewHandler, NewState} reply from
handle_event callback to be able to catch any exception from
Mod:handle_config_change. Effectively preventing gen_event manager from
killing config_listener_mon process. This trick allows us:

  - detect all kinds of failures and re-add handler
  - detect crash of gen_event manager to restart config_listener_mon

As a result of this change the config_listener behaviour modules need to
be updated to remove following code:

    handle_config_terminate(_Server, _Reason, State) ->
        spawn(fun() ->
            timer:sleep(5000),
            config:listen_for_changes(?MODULE, State)
        end).

The handler would be re-added automatically. You can disable this
behaviour by returning `remove_handler` atom from handle_config_terminate/3

COUCHDB-3102