### PR TITLE
handle_event expected to return {ok, State}

### DIFF
--- a/src/config_notifier.erl
+++ b/src/config_notifier.erl
@@ -45,7 +45,8 @@ init({Subscriber, Subscription}) ->
     {ok, {Subscriber, Subscription}}.
 
 handle_event({config_change, _, _, _, _} = Event, {Subscriber, Subscription}) ->
-    maybe_notify(Event, Subscriber, Subscription).
+    maybe_notify(Event, Subscriber, Subscription),
+    {ok, {Subscriber, Subscription}}.
 
 handle_call(_Request, St) ->
     {ok, ignored, St}.


### PR DESCRIPTION
Fix return value of handle_event callback.

gen_event behaviour requires handle_event callback to return `{ok, State}`

COUCHDB-3102