### PR TITLE
Features API and implementation.

### DIFF
--- a/src/config.erl
+++ b/src/config.erl
@@ -31,12 +31,16 @@
 -export([get_float/3, set_float/3]).
 -export([get_boolean/3, set_boolean/3]).
 
+-export([features/0, enable_feature/1, disable_feature/1]).
+
 -export([listen_for_changes/2]).
 -export([subscribe_for_changes/1]).
 -export([parse_ini_file/1]).
 
 -export([init/1, terminate/2, code_change/3]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
+
+-define(FEATURES, "features").
 
 -record(config, {
     notify_funs=[],
@@ -181,6 +185,18 @@ delete(Sec, Key, Persist, Reason) when is_binary(Sec) and is_binary(Key) ->
     delete(binary_to_list(Sec), binary_to_list(Key), Persist, Reason);
 delete(Section, Key, Persist, Reason) when is_list(Section), is_list(Key) ->
     gen_server:call(?MODULE, {delete, Section, Key, Persist, Reason}).
+
+
+features() ->
+    lists:usort([list_to_atom(Key) || {Key, "true"} <- ?MODULE:get(?FEATURES)]).
+
+
+enable_feature(Feature) when is_atom(Feature) ->
+    ?MODULE:set(?FEATURES, atom_to_list(Feature), "true", false).
+
+
+disable_feature(Feature) when is_atom(Feature) ->
+    ?MODULE:delete(?FEATURES, atom_to_list(Feature), false).
 
 
 listen_for_changes(CallbackModule, InitialState) ->

--- a/test/config_tests.erl
+++ b/test/config_tests.erl
@@ -172,6 +172,22 @@ config_del_test_() ->
     }.
 
 
+config_features_test_() ->
+    {
+        "Config features tests",
+        {
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                fun should_enable_features/0,
+                fun should_disable_features/0
+            ]
+        }
+    }.
+
+
+
 config_override_test_() ->
     {
         "Configs overide tests",
@@ -599,6 +615,32 @@ should_not_add_duplicate(_, _) ->
         ?assertEqual(2, n_notifiers()),
         ok
     end).
+
+
+should_enable_features() ->
+    ?assertEqual([], config:features()),
+
+    ?assertEqual(ok, config:enable_feature(snek)),
+    ?assertEqual([snek], config:features()),
+
+    ?assertEqual(ok, config:enable_feature(snek)),
+    ?assertEqual([snek], config:features()),
+
+    ?assertEqual(ok, config:enable_feature(dogo)),
+    ?assertEqual([dogo, snek], config:features()).
+
+
+should_disable_features() ->
+    ?assertEqual([], config:features()),
+
+    config:enable_feature(snek),
+    ?assertEqual([snek], config:features()),
+
+    ?assertEqual(ok, config:disable_feature(snek)),
+    ?assertEqual([], config:features()),
+
+    ?assertEqual(ok, config:disable_feature(snek)),
+    ?assertEqual([], config:features()).
 
 
 spawn_config_listener() ->


### PR DESCRIPTION
Implement ability to enable, disable and query feature flags.

Features are identified as binary strings. Usage intent is for
various components in the system to enable features, then the HTTP API will
expose those to the user. For example, features could indicate the presence
of an optional component, a plugin or a new mode of operation.

The API has 3 functions:
- `config:features/0` : Return a sorted list of feature flags
- `config:feature_enable/1` : Enables a feature. Feature argument could be a
  list, a binary or an atom.
- `config:feature_disable/1` : Same as `feature_enable/1` but disables the
  feature.

`feature_enable/1` and `feature_disable/1` are idempotent.

Implementation is a thin wrapper around setting and deleting keys from the
'[features]' config section. This means, users can also set their own features
there via the .ini config files. Features set via the API are not persistent,
so applications will have to set them every time they initialize.

Jira: COUCHDB-3180
