### PR TITLE
Lower default couchdb:max_dbs_open value in test suite

### DIFF
--- a/test/config_tests.erl
+++ b/test/config_tests.erl
@@ -366,7 +366,7 @@ should_be_ok_on_deleting_unknown_options() ->
 
 should_ensure_in_defaults(_, _) ->
     ?_test(begin
-        ?assertEqual("500", config:get("couchdb", "max_dbs_open")),
+        ?assertEqual("100", config:get("couchdb", "max_dbs_open")),
         ?assertEqual("5986", config:get("httpd", "port")),
         ?assertEqual(undefined, config:get("fizbang", "unicode"))
     end).


### PR DESCRIPTION
If apache/couchdb#763 is approved, this change is necessary to make the tests pass.