### PR TITLE
Fix nasty 500 error on POST to /_config

### DIFF
--- a/src/config.erl
+++ b/src/config.erl
@@ -266,8 +266,8 @@ handle_call({set, Sec, Key, Val, Persist, Reason}, _From, Config) ->
                     Event = {config_change, Sec, Key, Val, Persist},
                     gen_event:sync_notify(config_event, Event),
                     {reply, ok, Config};
-                {error, _Else} ->
-                    {reply, {error, _Else}, Config}
+                {error, Else} ->
+                    {reply, {error, Else}, Config}
             end
     end;
 
@@ -288,8 +288,8 @@ handle_call({delete, Sec, Key, Persist, Reason}, _From, Config) ->
             Event = {config_change, Sec, Key, deleted, Persist},
             gen_event:sync_notify(config_event, Event),
             {reply, ok, Config};
-        _Else ->
-            {reply, _Else, Config}
+        Else ->
+            {reply, Else, Config}
     end;
 
 handle_call(reload, _From, Config) ->

--- a/src/config.erl
+++ b/src/config.erl
@@ -253,7 +253,7 @@ handle_call({set, Sec, Key, Val, Persist, Reason}, _From, Config) ->
             true = ets:insert(?MODULE, {{Sec, Key}, Val}),
             couch_log:notice("~p: [~s] ~s set to ~s for reason ~p",
                              [?MODULE, Sec, Key, Val, Reason]),
-            case {Persist, Config#config.write_filename} of
+            ConfigWriteReturn = case {Persist, Config#config.write_filename} of
                 {true, undefined} ->
                     ok;
                 {true, FileName} ->
@@ -261,16 +261,21 @@ handle_call({set, Sec, Key, Val, Persist, Reason}, _From, Config) ->
                 _ ->
                     ok
             end,
-            Event = {config_change, Sec, Key, Val, Persist},
-            gen_event:sync_notify(config_event, Event),
-            {reply, ok, Config}
+            case ConfigWriteReturn of
+                ok ->
+                    Event = {config_change, Sec, Key, Val, Persist},
+                    gen_event:sync_notify(config_event, Event),
+                    {reply, ok, Config};
+                {error, _Else} ->
+                    {reply, {error, _Else}, Config}
+            end
     end;
 
 handle_call({delete, Sec, Key, Persist, Reason}, _From, Config) ->
     true = ets:delete(?MODULE, {Sec,Key}),
     couch_log:notice("~p: [~s] ~s deleted for reason ~p",
         [?MODULE, Sec, Key, Reason]),
-    case {Persist, Config#config.write_filename} of
+    ConfigDeleteReturn = case {Persist, Config#config.write_filename} of
         {true, undefined} ->
             ok;
         {true, FileName} ->
@@ -278,9 +283,15 @@ handle_call({delete, Sec, Key, Persist, Reason}, _From, Config) ->
         _ ->
             ok
     end,
-    Event = {config_change, Sec, Key, deleted, Persist},
-    gen_event:sync_notify(config_event, Event),
-    {reply, ok, Config};
+    case ConfigDeleteReturn of
+        ok ->
+            Event = {config_change, Sec, Key, deleted, Persist},
+            gen_event:sync_notify(config_event, Event),
+            {reply, ok, Config};
+        _Else ->
+            {reply, _Else, Config}
+    end;
+
 handle_call(reload, _From, Config) ->
     DiskKVs = lists:foldl(fun(IniFile, DiskKVs0) ->
         {ok, ParsedIniValues} = parse_ini_file(IniFile),

--- a/src/config_writer.erl
+++ b/src/config_writer.erl
@@ -35,7 +35,7 @@ save_to_file({{Section, Key}, Value}, File) ->
 
     NewLines = process_file_lines(Lines, [], SectionLine, Pattern, Key, Value),
     NewFileContents = reverse_and_add_newline(strip_empty_lines(NewLines), []),
-    ok = file:write_file(File, NewFileContents).
+    file:write_file(File, NewFileContents).
 
 
 process_file_lines([Section|Rest], SeenLines, Section, Pattern, Key, Value) ->

--- a/test/config_tests.erl
+++ b/test/config_tests.erl
@@ -299,7 +299,7 @@ config_notifier_behaviour_test_() ->
 
 config_access_right_test_() ->
     {
-        "Config file access right tests",
+        "Test config file access right",
         {
             foreach,
             fun setup/0,

--- a/test/config_tests.erl
+++ b/test/config_tests.erl
@@ -297,6 +297,45 @@ config_notifier_behaviour_test_() ->
     }.
 
 
+config_access_right_test_() ->
+    {
+        "Config file access right tests",
+        {
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                fun should_write_config_to_file/0,
+                fun should_delete_config_from_file/0,
+                fun should_not_write_config_to_file/0,
+                fun should_not_delete_config_from_file/0
+            ]
+        }
+    }.
+
+
+should_write_config_to_file() ->
+    ?assertEqual(ok, config:set("admins", "foo", "500", true)).
+
+
+should_delete_config_from_file() ->
+    ?assertEqual(ok, config:delete("admins", "foo", true)).
+
+
+should_not_write_config_to_file() ->
+    meck:new(config_writer),
+    meck:expect(config_writer, save_to_file, fun(_, _) -> {error, eacces} end),
+    ?assertEqual({error, eacces}, config:set("admins", "foo", "500", true)),
+    meck:unload(config_writer).
+
+
+should_not_delete_config_from_file() ->
+    meck:new(config_writer),
+    meck:expect(config_writer, save_to_file, fun(_, _) -> {error, eacces} end),
+    ?assertEqual({error, eacces}, config:delete("admins", "foo", true)),
+    meck:unload(config_writer).
+
+
 should_load_all_configs() ->
     ?assert(length(config:all()) > 0).
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

When the ini config file is read only,  function of 
`file:write_file(File, NewFileContents).` doesn't return `ok`, so for here we should handle the return error scenario. 


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

```
wenwl@wenwl_mbp:~/cloudant/couchdb$ chmod a-w ./dev/lib/node1/etc/local.ini
wenwl@wenwl_mbp:~/cloudant/couchdb$ curl -X PUT localhost:15984/_node/_local/_config/admins/joan1 -d '"500"' -u adm:pass
{"error":"bad_request","reason":"eacces"}
wenwl@wenwl_mbp:~/cloudant/couchdb$ curl -X DELETE localhost:15984/_node/_local/_config/admins/joan1 -u adm:pass
{"error":"bad_request","reason":"eacces"}
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

This PR and https://github.com/apache/couchdb/pull/1717  is for fixing issue of https://github.com/apache/couchdb/issues/1380
PR https://github.com/apache/couchdb/pull/1717 is dependent on this.
so this PR should be first merged into master, then https://github.com/apache/couchdb/pull/1717 can pick it up.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;




