### PR TITLE
Remove R16B03-1 build flavor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ otp_release:
   - 18.1
   - 18.0
   - 17.5
-  - R16B03-1
 
 sudo: false
 


### PR DESCRIPTION
## Overview

This PR is aimed to remove `R16B03-1 build` flavor.

```
0.92s$ git clone --depth 1 https://github.com/apache/couchdb
Cloning into 'couchdb'...
remote: Enumerating objects: 919, done.
remote: Counting objects: 100% (919/919), done.
remote: Compressing objects: 100% (828/828), done.
remote: Total 919 (delta 212), reused 276 (delta 64), pack-reused 0
Receiving objects: 100% (919/919), 1.40 MiB | 11.64 MiB/s, done.
Resolving deltas: 100% (212/212), done.
before_script.1
0.00s$ cd couchdb
before_script.2
21.49s$ ./configure --disable-docs --disable-fauxton
==> configuring couchdb in rel/couchdb.config
Cloning into '/home/travis/build/apache/couchdb-config/couchdb/src/rebar'...
remote: Enumerating objects: 440, done.
remote: Counting objects: 100% (440/440), done.
remote: Compressing objects: 100% (338/338), done.
remote: Total 440 (delta 80), reused 281 (delta 34), pack-reused 0
Receiving objects: 100% (440/440), 273.93 KiB | 10.96 MiB/s, done.
Resolving deltas: 100% (80/80), done.
make: Entering directory `/home/travis/build/apache/couchdb-config/couchdb/src/rebar'
./bootstrap
No beam files found.
Recompile: src/rebar
Recompile: src/rebar_abnfc_compiler
Recompile: src/rebar_app_utils
Recompile: src/rebar_appups
Recompile: src/rebar_asn1_compiler
Recompile: src/rebar_base_compiler
Recompile: src/rebar_cleaner
Recompile: src/rebar_config
Recompile: src/rebar_core
Recompile: src/rebar_cover_utils
Recompile: src/rebar_ct
Recompile: src/rebar_deps
Recompile: src/rebar_dia_compiler
Recompile: src/rebar_dialyzer
Recompile: src/rebar_edoc
Recompile: src/rebar_erlc_compiler
Recompile: src/rebar_erlydtl_compiler
Recompile: src/rebar_escripter
Recompile: src/rebar_eunit
Recompile: src/rebar_file_utils
Recompile: src/rebar_getopt
Recompile: src/rebar_lfe_compiler
Recompile: src/rebar_log
Recompile: src/rebar_metacmds
Recompile: src/rebar_mustache
Recompile: src/rebar_neotoma_compiler
Recompile: src/rebar_otp_app
Recompile: src/rebar_otp_appup
Recompile: src/rebar_port_compiler
Recompile: src/rebar_proto_compiler
Recompile: src/rebar_proto_gpb_compiler
Recompile: src/rebar_protobuffs_compiler
Recompile: src/rebar_qc
Recompile: src/rebar_rand_compat
Recompile: src/rebar_rel_utils
Recompile: src/rebar_reltool
Recompile: src/rebar_require_vsn
Recompile: src/rebar_shell
Recompile: src/rebar_subdirs
Recompile: src/rebar_templater
Recompile: src/rebar_upgrade
Recompile: src/rebar_utils
Recompile: src/rebar_xref
Recompile: src/rmemo
==> rebar (compile)
==> rebar (escriptize)
Congratulations! You now have a self-contained script called "rebar" in
your current working directory. Place this script anywhere in your path
and you can use rebar to build OTP-compliant apps.
make: Leaving directory `/home/travis/build/apache/couchdb-config/couchdb/src/rebar'
make: Entering directory `/home/travis/build/apache/couchdb-config/couchdb/src/rebar'
make: Leaving directory `/home/travis/build/apache/couchdb-config/couchdb/src/rebar'
==> updating dependencies
WARN:  Expected /home/travis/build/apache/couchdb-config/couchdb/src/docs to be a raw dependency directory, but no directory found.
WARN:  Expected /home/travis/build/apache/couchdb-config/couchdb/src/fauxton to be a raw dependency directory, but no directory found.
==> couch_epi (get-deps)
==> couch_log (get-deps)
==> chttpd (get-deps)
==> couch (get-deps)
==> couch_index (get-deps)
==> couch_mrview (get-deps)
==> couch_replicator (get-deps)
==> couch_plugins (get-deps)
==> couch_pse_tests (get-deps)
==> couch_event (get-deps)
==> couch_stats (get-deps)
==> couch_peruser (get-deps)
==> couch_tests (get-deps)
==> ddoc_cache (get-deps)
==> fabric (get-deps)
==> global_changes (get-deps)
==> mango (get-deps)
==> mem3 (get-deps)
==> rexi (get-deps)
==> setup (get-deps)
==> rel (get-deps)
==> couchdb (get-deps)
WARN:  Expected /home/travis/build/apache/couchdb-config/couchdb/src/docs to be a raw dependency directory, but no directory found.
WARN:  Expected /home/travis/build/apache/couchdb-config/couchdb/src/fauxton to be a raw dependency directory, but no directory found.
Pulling config from {git,"https://github.com/apache/couchdb-config.git",
                         {tag,"1.0.4"}}
Cloning into 'config'...
Pulling b64url from {git,"https://github.com/apache/couchdb-b64url.git",
                         {tag,"1.0.1"}}
Cloning into 'b64url'...
Pulling ets_lru from {git,"https://github.com/apache/couchdb-ets-lru.git",
                          {tag,"1.0.0"}}
Cloning into 'ets_lru'...
Pulling khash from {git,"https://github.com/apache/couchdb-khash.git",
                        {tag,"1.0.1"}}
Cloning into 'khash'...
Pulling snappy from {git,"https://github.com/apache/couchdb-snappy.git",
                         {tag,"CouchDB-1.0.2"}}
Cloning into 'snappy'...
Pulling ioq from {git,"https://github.com/apache/couchdb-ioq.git",
                      {tag,"1.0.1"}}
Cloning into 'ioq'...
Pulling docs from {git,"https://github.com/apache/couchdb-documentation",
                       {tag,"2.2.0"}}
Cloning into 'docs'...
Pulling fauxton from {git,"https://github.com/apache/couchdb-fauxton",
                          {tag,"v1.1.18"}}
Cloning into 'fauxton'...
Pulling folsom from {git,"https://github.com/apache/couchdb-folsom.git",
                         {tag,"CouchDB-0.8.2"}}
Cloning into 'folsom'...
Pulling hyper from {git,"https://github.com/apache/couchdb-hyper.git",
                        {tag,"CouchDB-2.2.0-4"}}
Cloning into 'hyper'...
Pulling ibrowse from {git,"https://github.com/apache/couchdb-ibrowse.git",
                          {tag,"CouchDB-4.0.1"}}
Cloning into 'ibrowse'...
Pulling jiffy from {git,"https://github.com/apache/couchdb-jiffy.git",
                        {tag,"CouchDB-0.14.11-2"}}
Cloning into 'jiffy'...
Pulling mochiweb from {git,"https://github.com/apache/couchdb-mochiweb.git",
                           {tag,"CouchDB-v2.18.0-1"}}
Cloning into 'mochiweb'...
Pulling meck from {git,"https://github.com/apache/couchdb-meck.git",
                       {tag,"0.8.8"}}
Cloning into 'meck'...
==> config (get-deps)
==> b64url (get-deps)
==> ets_lru (get-deps)
==> khash (get-deps)
==> snappy (get-deps)
==> ioq (get-deps)
==> docs (get-deps)
==> fauxton (get-deps)
==> meck (get-deps)
==> folsom (get-deps)
Pulling bear from {git,"https://github.com/apache/couchdb-bear.git",
                       "008f48aff819126e281d5ccae80a258bf9bf9c30"}
Cloning into 'bear'...
==> bear (get-deps)
==> hyper (get-deps)
Pulling triq from {git,"https://github.com/apache/couchdb-triq.git",
                       {tag,"v1.2.0"}}
Cloning into 'triq'...
==> triq (get-deps)
==> ibrowse (get-deps)
==> jiffy (get-deps)
==> mochiweb (get-deps)
==> couchdb (update-deps)
Updating config from {git,"https://github.com/apache/couchdb-config.git",
                          {tag,"1.0.4"}}
Updating b64url from {git,"https://github.com/apache/couchdb-b64url.git",
                          {tag,"1.0.1"}}
Updating ets_lru from {git,"https://github.com/apache/couchdb-ets-lru.git",
                           {tag,"1.0.0"}}
Updating khash from {git,"https://github.com/apache/couchdb-khash.git",
                         {tag,"1.0.1"}}
Updating snappy from {git,"https://github.com/apache/couchdb-snappy.git",
                          {tag,"CouchDB-1.0.2"}}
Updating ioq from {git,"https://github.com/apache/couchdb-ioq.git",
                       {tag,"1.0.1"}}
Updating docs from {git,"https://github.com/apache/couchdb-documentation",
                        {tag,"2.2.0"}}
Updating fauxton from {git,"https://github.com/apache/couchdb-fauxton",
                           {tag,"v1.1.18"}}
Updating folsom from {git,"https://github.com/apache/couchdb-folsom.git",
                          {tag,"CouchDB-0.8.2"}}
Updating hyper from {git,"https://github.com/apache/couchdb-hyper.git",
                         {tag,"CouchDB-2.2.0-4"}}
Updating ibrowse from {git,"https://github.com/apache/couchdb-ibrowse.git",
                           {tag,"CouchDB-4.0.1"}}
Updating jiffy from {git,"https://github.com/apache/couchdb-jiffy.git",
                         {tag,"CouchDB-0.14.11-2"}}
Updating mochiweb from {git,"https://github.com/apache/couchdb-mochiweb.git",
                            {tag,"CouchDB-v2.18.0-1"}}
Updating meck from {git,"https://github.com/apache/couchdb-meck.git",
                        {tag,"0.8.8"}}
Updating bear from {git,"https://github.com/apache/couchdb-bear.git",
                        "008f48aff819126e281d5ccae80a258bf9bf9c30"}
Updating triq from {git,"https://github.com/apache/couchdb-triq.git",
                        {tag,"v1.2.0"}}
You have configured Apache CouchDB, time to relax. Relax.
before_script.3
0.09s$ cp -r ../!(couchdb) ./src/config
2.33s$ make
fatal: No names found, cannot describe anything.
==> config (compile)
ERROR: OTP release R16B03-1 does not match required regex 17|18|19|20|21
ERROR: compile failed while processing /home/travis/build/apache/couchdb-config/couchdb/src/config: rebar_abort
make: *** [couch] Error 1
```



## Testing recommendations

All tests should pass. 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;

