### PR TITLE
Keep features on config process restart.

### DIFF
--- a/src/config.erl
+++ b/src/config.erl
@@ -204,16 +204,15 @@ delete(Section, Key, Persist, Reason) when is_list(Section), is_list(Key) ->
 
 
 features() ->
-    lists:usort([list_to_atom(Key) || {Key, "true"} <- ?MODULE:get(?FEATURES)]).
-
+    application:get_env(config, enabled_features, []).
 
 enable_feature(Feature) when is_atom(Feature) ->
-    ?MODULE:set(?FEATURES, atom_to_list(Feature), "true", false).
-
+    application:set_env(config, enabled_features,
+        lists:usort([Feature | features()]), [{persistent, true}]).
 
 disable_feature(Feature) when is_atom(Feature) ->
-    ?MODULE:delete(?FEATURES, atom_to_list(Feature), false).
-
+    application:set_env(config, enabled_features,
+        features() -- [Feature], [{persistent, true}]).
 
 listen_for_changes(CallbackModule, InitialState) ->
     config_listener_mon:subscribe(CallbackModule, InitialState).


### PR DESCRIPTION
We used to store a list of enabled features in ets table owned by `config`
process. This meant that on every `config` process restart we loose the
list. Therefore welcome endpoint start to return empty list of features.

Use application environment to keep the list.

fixes #1930

# Testing recommendation

```
make eunit apps=config
```