### PR TITLE
Fix regex to trim more than one space before comment

### DIFF
--- a/src/config.erl
+++ b/src/config.erl
@@ -394,7 +394,7 @@ parse_ini_file(IniFile) ->
                     case {MultiLineValuePart, AccValues} of
                     {true, [{{_, ValueName}, PrevValue} | AccValuesRest]} ->
                         % remove comment
-                        case re:split(Value, " ;|\t;", [{return, list}]) of
+                        case re:split(Value, "\s+;|\t;", [{return, list}]) of
                         [[]] ->
                             % empty line
                             {AccSectionName, AccValues};
@@ -411,7 +411,7 @@ parse_ini_file(IniFile) ->
                 [ValueName|LineValues] -> % yeehaw, got a line!
                     RemainingLine = config_util:implode(LineValues, "="),
                     % removes comments
-                    case re:split(RemainingLine, " ;|\t;", [{return, list}]) of
+                    case re:split(RemainingLine, "\s+;|\t;", [{return, list}]) of
                     [[]] ->
                         % empty line means delete this key
                         ets:delete(?MODULE, {AccSectionName, ValueName}),

--- a/test/fixtures/config_tests_2.ini
+++ b/test/fixtures/config_tests_2.ini
@@ -5,7 +5,7 @@
 ; to you under the Apache License, Version 2.0 (the
 ; "License"); you may not use this file except in compliance
 ; with the License.  You may obtain a copy of the License at
-; 
+;
 ;   http://www.apache.org/licenses/LICENSE-2.0
 ;
 ; Unless required by applicable law or agreed to in writing,
@@ -16,7 +16,7 @@
 ; under the License.
 
 [httpd]
-port = 80
+port = 80    ; more than 1 ws before comments
 
 [fizbang]
 unicode = normalized


### PR DESCRIPTION
For https://github.com/apache/couchdb/issues/3259