### PR TITLE
Feat/allow escaped equals

### DIFF
--- a/src/config.erl
+++ b/src/config.erl
@@ -251,7 +251,7 @@ handle_call({set, Sec, Key, Val, Opts}, _From, Config) ->
     case validate_config_update(Sec, Key, Val) of
         {error, ValidationError} when IsSensitive ->
             couch_log:error("~p: [~s] ~s = '****' rejected for reason ~p",
-                              [?MODULE, Sec, Key, Reason]),
+                             [?MODULE, Sec, Key, Reason]),
             {reply, {error, ValidationError}, Config};
         {error, ValidationError} ->
             couch_log:error("~p: [~s] ~s = '~s' rejected for reason ~p",

--- a/src/config.erl
+++ b/src/config.erl
@@ -251,7 +251,7 @@ handle_call({set, Sec, Key, Val, Opts}, _From, Config) ->
     case validate_config_update(Sec, Key, Val) of
         {error, ValidationError} when IsSensitive ->
             couch_log:error("~p: [~s] ~s = '****' rejected for reason ~p",
-                            [?MODULE, Sec, Key, Reason]),
+                           [?MODULE, Sec, Key, Reason]),
             {reply, {error, ValidationError}, Config};
         {error, ValidationError} ->
             couch_log:error("~p: [~s] ~s = '~s' rejected for reason ~p",

--- a/src/config.erl
+++ b/src/config.erl
@@ -251,7 +251,7 @@ handle_call({set, Sec, Key, Val, Opts}, _From, Config) ->
     case validate_config_update(Sec, Key, Val) of
         {error, ValidationError} when IsSensitive ->
             couch_log:error("~p: [~s] ~s = '****' rejected for reason ~p",
-                                [?MODULE, Sec, Key, Reason]),
+                            [?MODULE, Sec, Key, Reason]),
             {reply, {error, ValidationError}, Config};
         {error, ValidationError} ->
             couch_log:error("~p: [~s] ~s = '~s' rejected for reason ~p",

--- a/src/config.erl
+++ b/src/config.erl
@@ -251,7 +251,7 @@ handle_call({set, Sec, Key, Val, Opts}, _From, Config) ->
     case validate_config_update(Sec, Key, Val) of
         {error, ValidationError} when IsSensitive ->
             couch_log:error("~p: [~s] ~s = '****' rejected for reason ~p",
-                           [?MODULE, Sec, Key, Reason]),
+                              [?MODULE, Sec, Key, Reason]),
             {reply, {error, ValidationError}, Config};
         {error, ValidationError} ->
             couch_log:error("~p: [~s] ~s = '~s' rejected for reason ~p",

--- a/test/config_tests.erl
+++ b/test/config_tests.erl
@@ -36,6 +36,9 @@
 -define(CONFIG_FIXTURE_2,
         filename:join([?CONFIG_FIXTURESDIR, "config_tests_2.ini"])).
 
+-define(CONFIG_FIXTURE_ESCAPING,
+        filename:join([?CONFIG_FIXTURESDIR, "config_tests_escaping.ini"])).
+
 -define(CONFIG_DEFAULT_D,
         filename:join([?CONFIG_FIXTURESDIR, "default.d"])).
 
@@ -89,6 +92,8 @@ setup_config_notifier(Subscription) ->
     Pid = spawn_config_notifier(Subscription),
     {Apps, Pid}.
 
+setup_with_escaped_chars() ->
+    setup(?CONFIG_CHAIN ++ [?CONFIG_FIXTURE_ESCAPING]).
 
 teardown({Apps, Pid}) when is_pid(Pid) ->
     catch exit(Pid, kill),
@@ -130,7 +135,7 @@ config_get_test_() ->
         "Config get tests",
         {
             foreach,
-            fun setup/0,
+            fun setup_with_escaped_chars/0,
             fun teardown/1,
             [
                 fun should_load_all_configs/0,
@@ -139,7 +144,8 @@ config_get_test_() ->
                 fun should_return_custom_default_value_on_missed_option/0,
                 fun should_only_return_default_on_missed_option/0,
                 fun should_fail_to_get_binary_value/0,
-                fun should_return_any_supported_default/0
+                fun should_return_any_supported_default/0,
+                fun should_return_values_from_escaped_keys/0
             ]
         }
     }.
@@ -374,6 +380,9 @@ should_return_undefined_atom_on_missed_option() ->
 should_return_custom_default_value_on_missed_option() ->
     ?assertEqual("bar", config:get("httpd", "foo", "bar")).
 
+should_return_values_from_escaped_keys() ->
+    ?assertEqual("somepass", config:get("admins", "sample=user")),
+    ?assertEqual("somevalue", config:get("jwt_tokens","kid:somekey=")).
 
 should_only_return_default_on_missed_option() ->
     ?assertEqual("0", config:get("httpd", "port", "bar")).

--- a/test/fixtures/config_tests_escaping.ini
+++ b/test/fixtures/config_tests_escaping.ini
@@ -1,0 +1,23 @@
+; Licensed to the Apache Software Foundation (ASF) under one
+; or more contributor license agreements.  See the NOTICE file
+; distributed with this work for additional information
+; regarding copyright ownership.  The ASF licenses this file
+; to you under the Apache License, Version 2.0 (the
+; "License"); you may not use this file except in compliance
+; with the License.  You may obtain a copy of the License at
+;
+;   http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing,
+; software distributed under the License is distributed on an
+; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+; KIND, either express or implied.  See the License for the
+; specific language governing permissions and limitations
+; under the License.
+
+[admins]
+test=value
+sample\=user = somepass
+
+[jwt_tokens]
+kid:somekey\= = somevalue


### PR DESCRIPTION
Refactor of config file parser in order to allow equals characters on the keys escaping them with a backslash.

Needed for allowing declaring jwt:kid certificates whose kid contains equal signs.

Related with these two bugs:
apache/couchdb#3319
apache/couchdb#2188