### PR TITLE
Implement is_sensitive/2 using configurable application env

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,2 @@
+{cover_enabled, true}.
+{cover_print_enabled, true}.

--- a/src/config.app.src.script
+++ b/src/config.app.src.script
@@ -10,6 +10,15 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
+ConfigPath = filename:join([os:getenv("COUCHDB_APPS_CONFIG_DIR"), "config.config"]),
+AppEnv = case filelib:is_file(ConfigPath) of
+    true ->
+        {ok, Result} = file:consult(ConfigPath),
+        Result;
+    false ->
+        []
+end.
+
 {application, config, [
     {description, "INI file configuration system for Apache CouchDB"},
     {vsn, git},
@@ -18,5 +27,6 @@
         config_event
     ]},
     {applications, [kernel, stdlib]},
-    {mod, {config_app, []}}
+    {mod, {config_app, []}},
+    {env, AppEnv}
 ]}.


### PR DESCRIPTION
If it exists, consult a file to configure application env. If
`sensitive` env key is found therein, use it to determine which values
to redact from log entries. The value of the `sensitive` key should be
a dict of the form:
```
#{
    Section1 => [Field1, Field2, ...],
    Section2 => all
}
```
where `Section`s are strings that define sections which contain
sensitive fields, and `Field`s are strings. The atom `all` indicates
all fields for that section are sensitive. A typical configuration
might look like:
```
#{
    "admins" => all,
    "replicator" => ["password"]
}
```
meaning that all values in the `[admins]` section, and the `password`
value in the `[replicator]` section will be redacted from the logs.