### PR TITLE
export to_integer, to_boolean for PR#3567

### DIFF
--- a/src/config.erl
+++ b/src/config.erl
@@ -90,7 +90,8 @@ to_integer(List) when is_list(List) ->
 to_integer(Int) when is_integer(Int) ->
     Int;
 to_integer(Bin) when is_binary(Bin) ->
-    list_to_integer(binary_to_list(Bin)).
+    list_to_integer(binary_to_list(Bin));
+to_integer(_) -> error(badarg).
 
 get_float(Section, Key, Default) when is_float(Default) ->
     try
@@ -145,7 +146,8 @@ to_boolean(List) when is_list(List) ->
             error(badarg)
     end;
 to_boolean(Bool) when is_boolean(Bool) ->
-    Bool.
+    Bool;
+to_boolean(_) -> error(badarg).
 
 get(Section) when is_binary(Section) ->
     ?MODULE:get(binary_to_list(Section));

--- a/src/config.erl
+++ b/src/config.erl
@@ -31,6 +31,8 @@
 -export([get_float/3, set_float/3, set_float/4]).
 -export([get_boolean/3, set_boolean/3, set_boolean/4]).
 
+-export([to_integer/1, to_boolean/1]).
+
 -export([features/0, enable_feature/1, disable_feature/1]).
 
 -export([listen_for_changes/2]).


### PR DESCRIPTION
CouchDB 3.x: Move config options from [httpd] to [chttpd] [WIP] #3567
I need to use to_integer() and to_boolean() functions in this PR, which is used in the chttp_util.erl file.
https://github.com/apache/couchdb/pull/3567