### PR TITLE
Isolate CI tests from default.ini changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: erlang
 
 otp_release:
+  - 24.0
   - 21.1
-  - 20.3
 
 env:
   - COUCHDB_BRANCH=main

--- a/test/config_tests.erl
+++ b/test/config_tests.erl
@@ -30,6 +30,9 @@
 -define(CONFIG_FIXTURESDIR,
         filename:join([?BUILDDIR(), "src", "config", "test", "fixtures"])).
 
+-define(CONFIG_DEFAULT_TEST,
+        filename:join([?CONFIG_FIXTURESDIR, "config_default_test.ini"])).
+
 -define(CONFIG_FIXTURE_1,
         filename:join([?CONFIG_FIXTURESDIR, "config_tests_1.ini"])).
 
@@ -201,20 +204,20 @@ config_override_test_() ->
             fun setup/1,
             fun teardown/2,
             [
-                {{temporary, [?CONFIG_DEFAULT]},
+                {{temporary, [?CONFIG_DEFAULT_TEST]},
                         fun should_ensure_in_defaults/2},
-                {{temporary, [?CONFIG_DEFAULT, ?CONFIG_FIXTURE_1]},
+                {{temporary, [?CONFIG_DEFAULT_TEST, ?CONFIG_FIXTURE_1]},
                         fun should_override_options/2},
-                {{temporary, [?CONFIG_DEFAULT, ?CONFIG_FIXTURE_2]},
+                {{temporary, [?CONFIG_DEFAULT_TEST, ?CONFIG_FIXTURE_2]},
                         fun should_create_new_sections_on_override/2},
-                {{temporary, [?CONFIG_DEFAULT, ?CONFIG_FIXTURE_1,
+                {{temporary, [?CONFIG_DEFAULT_TEST, ?CONFIG_FIXTURE_1,
                                 ?CONFIG_FIXTURE_2]},
                         fun should_win_last_in_chain/2},
-                {{temporary, [?CONFIG_DEFAULT, ?CONFIG_DEFAULT_D]},
+                {{temporary, [?CONFIG_DEFAULT_TEST, ?CONFIG_DEFAULT_D]},
                         fun should_read_default_d/2},
-                {{temporary, [?CONFIG_DEFAULT, ?CONFIG_LOCAL_D]},
+                {{temporary, [?CONFIG_DEFAULT_TEST, ?CONFIG_LOCAL_D]},
                         fun should_read_local_d/2},
-                {{temporary, [?CONFIG_DEFAULT, ?CONFIG_DEFAULT_D,
+                {{temporary, [?CONFIG_DEFAULT_TEST, ?CONFIG_DEFAULT_D,
                                 ?CONFIG_LOCAL_D]},
                         fun should_read_default_and_local_d/2}
             ]
@@ -230,9 +233,9 @@ config_persistent_changes_test_() ->
             fun setup/1,
             fun teardown/2,
             [
-                {{persistent, [?CONFIG_DEFAULT]},
+                {{persistent, [?CONFIG_DEFAULT_TEST]},
                         fun should_write_changes/2},
-                {{temporary, [?CONFIG_DEFAULT]},
+                {{temporary, [?CONFIG_DEFAULT_TEST]},
                         fun should_ensure_default_wasnt_modified/2},
                 {{temporary, [?CONFIG_FIXTURE_TEMP]},
                         fun should_ensure_written_to_last_config_in_chain/2}

--- a/test/fixtures/config_default_test.ini
+++ b/test/fixtures/config_default_test.ini
@@ -1,0 +1,23 @@
+; Licensed to the Apache Software Foundation (ASF) under one
+; or more contributor license agreements.  See the NOTICE file
+; distributed with this work for additional information
+; regarding copyright ownership.  The ASF licenses this file
+; to you under the Apache License, Version 2.0 (the
+; "License"); you may not use this file except in compliance
+; with the License.  You may obtain a copy of the License at
+; 
+;   http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing,
+; software distributed under the License is distributed on an
+; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+; KIND, either express or implied.  See the License for the
+; specific language governing permissions and limitations
+; under the License.
+
+[couchdb]
+max_dbs_open = 500
+
+[httpd]
+port = 5986
+bind_address = 127.0.0.1


### PR DESCRIPTION
## Overview
In order to comment out some configuration options for the CouchDB, I need to isolate the tests in config from the default.ini changes.

## Related Issues or Pull Requests
https://github.com/apache/couchdb/issues/3473
https://github.com/apache/couchdb/pull/3609