### PR TITLE
Remove leading/trailing whitespaces in config values

### DIFF
--- a/src/config.erl
+++ b/src/config.erl
@@ -437,8 +437,9 @@ parse_ini_file(IniFile) ->
                         ets:delete(?MODULE, {AccSectionName, ValueName}),
                         {AccSectionName, AccValues};
                     [LineValue | _Rest] ->
+                        LineValueWithoutLeadTrailWS = string:trim(LineValue),
                         {AccSectionName,
-                            [{{AccSectionName, ValueName}, LineValue} | AccValues]}
+                            [{{AccSectionName, ValueName}, LineValueWithoutLeadTrailWS} | AccValues]}
                     end
                 end
             end

--- a/src/config_util.erl
+++ b/src/config_util.erl
@@ -72,3 +72,4 @@ fix_path_list(["."|Rest], Acc) ->
     fix_path_list(Rest, Acc);
 fix_path_list([Dir | Rest], Acc) ->
     fix_path_list(Rest, [Dir | Acc]).
+


### PR DESCRIPTION
Remove leading and trailing white-spaces from config values:
Config:
```ini
option =                                  value                                        ; Leading and trailing ws in value
```

This would read CouchDB as
```
option="                                 value                                        "
```
and after this change as
```
option="value"
```
